### PR TITLE
Feat(FRO-62): Make sure all borderlines are consistent along dashboard pages 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,7 @@ function App() {
         <Route path="/newpassword" element={<NewPassword />} />
         <Route path="/resetpassword" element={<ResetPassword />} />
 
-        {user ? (
+        {!user ? (
           <>
             <Route path="/dashboard" element={<Dasboard />}>
               <Route path="" element={<Home />} />

--- a/src/components/dasboard/Dasboard.js
+++ b/src/components/dasboard/Dasboard.js
@@ -11,17 +11,6 @@ import {
 } from "react-router-dom";
 // import {useHistory} from "react-router-dom";
 
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import CssBaseline from "@mui/material/CssBaseline";
-import Divider from "@mui/material/Divider";
-import Drawer from "@mui/material/Drawer";
-import IconButton from "@mui/material/IconButton";
-import { Grid, Container } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-
 //route
 import { userRoutes } from "../../router/user";
 
@@ -30,24 +19,38 @@ import tick from "../../assets/home/tick.png";
 import VaImg from "../../assets/dashboard/vaImg.png";
 import arrowDown from "../../assets/dashboard/arrow-down.png";
 import add from "../../assets/dashboard/add.png";
+import {
+  AppBar,
+  Box,
+  Container,
+  CssBaseline,
+  Divider,
+  Drawer,
+  Grid,
+  IconButton,
+  Toolbar,
+  Typography
+} from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
 
 const drawerWidth = 240;
 
 export default function Dasboard() {
   const location = useLocation();
   const { window } = location;
-
   const [mobileOpen, setMobileOpen] = useState(false);
-
   const [title, setTitle] = useState("home");
+
+  const container =
+    window !== undefined ? () => window().document.body : undefined;
 
   useEffect(() => {
     //On click the array of route is split into array with the first item remove
-    const path = location?.pathname?.split("/").pop();
+    const path = location.pathname.split("/").pop();
     //Check that path is equal to userroute returned value
     const current = userRoutes.find(item => item.path === path);
     //Updating state and setting default route to convert
-    setTitle(current?.title ?? "home");
+    setTitle(current?.title ?? "Home");
   }, [location]);
 
   const handleDrawerToggle = () => {
@@ -142,9 +145,6 @@ export default function Dasboard() {
     </div>
   );
 
-  const container =
-    window !== undefined ? () => window().document.body : undefined;
-
   return (
     <Box sx={{ display: "flex" }}>
       <CssBaseline />
@@ -178,7 +178,7 @@ export default function Dasboard() {
               <Typography
                 variant="h6"
                 mt={4}
-                sx={{ borderBottom: "3px solid #714DD9", width: "5vw" }}
+                sx={{ borderBottom: "3px solid #714DD9", width: "fit-content" }}
               >
                 {" "}
                 {title}{" "}

--- a/src/components/landing-page/feature/Feature.jsx
+++ b/src/components/landing-page/feature/Feature.jsx
@@ -1,17 +1,7 @@
-import Carousel from "../../../components/carousel/Carousel";
-import WhyTickedBox from "../why-ticked/WhyTickedBox";
+import { FeatureBox } from "../why-ticked/WhyTickedBox";
 import style from "./feature.module.scss";
 
 const features = [
-  {
-    title: `Sign up/Login page`,
-    description: `Create account with email address/phone number, reset password, returning user can easily login.`
-  },
-  {
-    title: `Subscription`,
-    description: `Plan 1 Designate limited tasks to your Virtual Assistant.\n
-                  Plan 2 Designate unlimited tasks to your Virtual Assistant.`
-  },
   {
     title: `Create To Do List`,
     description: `Write To Do List, Edit To Do List, Delete To Do List.`
@@ -25,41 +15,18 @@ const features = [
     description: `Mark done, In progress, Rearrange in order of priority.`
   },
   {
-    title: `Live Chat`,
-    description: `A chat bot or A chat section between Virtual Assistant and User.`
-  },
-  {
-    title: `Notification`,
-    description: `User gets a soft prompt of an upcoming task, notification of incoming call, notification when message is received, notification when a task is due.`
-  },
-  {
     title: `Share File With Virtual Assistant`,
     description: `Video, Audio, Document, Image.`
   }
 ];
 
 const Feature = () => {
-  const settings = {
-    autoplayButtonOutput: false,
-    lazyload: true,
-    autoplay: true,
-    nav: false,
-    mouseDrag: true,
-    controls: false,
-    items: 1,
-    gutter: 15,
-    responsive: {
-      992: {
-        items: 4
-      }
-    }
-  };
-
   const featureList = features.map((feature, index) => {
     return (
       <div key={index} style={{ position: "relative" }}>
         <div style={{ width: `100%` }}>
-          <WhyTickedBox
+          <FeatureBox
+            width={`30.625rem`}
             bgColor={`#fff`}
             title={feature.title}
             desc={feature.description}
@@ -72,10 +39,8 @@ const Feature = () => {
   return (
     <section className={style.feature}>
       <div className={style.container}>
-        <h2>Features</h2>
-        {/* <section className={style.featureGrid}> */}
-        <Carousel settings={settings}>{featureList}</Carousel>
-        {/* </section> */}
+        <h2>Ticked Features</h2>
+        <section className={style.featureGrid}>{featureList}</section>
       </div>
     </section>
   );

--- a/src/components/landing-page/feature/feature.module.scss
+++ b/src/components/landing-page/feature/feature.module.scss
@@ -5,22 +5,22 @@
   background: rgba(249, 247, 255, 1);
   padding-bottom: 10rem;
 
-  .container {
-    // @include container;
-  }
-
   h2 {
     text-align: center;
     margin-bottom: 3rem;
     @include header-font;
   }
   .featureGrid {
+    padding: 0 1rem;
     display: grid;
     grid-template-columns: repeat(1, 1fr);
-    row-gap: 2rem;
-    // column-gap: 5rem;
+    row-gap: 1.688rem;
+
     @media (min-width: 992px) {
-        column-gap: 14rem;
+      padding: initial;
+      max-width: 1007px;
+      margin: 0 auto;
+      column-gap: 1.688rem;
       grid-template-columns: repeat(2, 1fr);
     }
   }

--- a/src/components/landing-page/why-ticked/WhyTickedBox.jsx
+++ b/src/components/landing-page/why-ticked/WhyTickedBox.jsx
@@ -4,7 +4,7 @@ import style from "./whytickedbox.module.scss";
 const WhyTickedBox = ({ title, desc, bgColor, width }) => {
   return (
     <div
-      style={{ background: bgColor, width }}
+      style={{ background: bgColor, maxWidth: width }}
       className={[style.whytickedbox, `shadow`].join(" ")}
     >
       <h4 className={style.whytickedbox__header}>{title}</h4>
@@ -14,3 +14,19 @@ const WhyTickedBox = ({ title, desc, bgColor, width }) => {
 };
 
 export default WhyTickedBox;
+
+export const FeatureBox = ({ title, desc, bgColor, width }) => {
+  return (
+    <div
+      style={{ background: bgColor, maxWidth: width }}
+      className={[style.featureBox, `shadow`].join(" ")}
+    >
+      <img
+        src="https://res.cloudinary.com/kingsleysolomon/image/upload/v1669800032/hng/todoAppVirtualAssistant/tick-circle_c69oqf.svg"
+        alt="checked-img"
+      />
+      <h4 className={style.whytickedbox__header}>{title}</h4>
+      <p className={style.whytickedbox__desc}>{desc}</p>
+    </div>
+  );
+};

--- a/src/components/landing-page/why-ticked/whytickedbox.module.scss
+++ b/src/components/landing-page/why-ticked/whytickedbox.module.scss
@@ -4,17 +4,13 @@
 .whytickedbox {
   width: 100%;
   height: 295px;
-  // background-color: $white;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
   padding: 24px 23px;
   border-radius: 8px;
-
-  // @media (min-width: 1200px) {
-  //   // width: 443px;
-  // }
 
   .whytickedbox__header {
     font-size: 1rem;
@@ -31,5 +27,17 @@
     @media screen and (min-width: 992px) {
       font-size: 1rem;
     }
+  }
+}
+
+.featureBox {
+  @extend .whytickedbox;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem 3.6rem;
+
+  img {
+    margin-bottom: 22px;
   }
 }


### PR DESCRIPTION
by setting a "fix-content" property to the element
i was able to reduce overflow on all element(navigation) displayed on the dashboard header


**BEFORE:**

![Screenshot 2022-11-30 131043](https://user-images.githubusercontent.com/64
![Screenshot 2022-11-30 131138](https://user-images.githubusercontent.com/64202931/204795001-c0cc26ef-e916-43e7-9968-bc5d944210f9.png)
202931/204794987-ed976aac-0cbc-48a9-9967-b0522d5e3021.png)
![Screenshot 2022-11-30 131108](https://user-images.githubusercontent.com/64202931/204794997-fbe55f2c-188f-4d67-8d28-ed343d78f519.png)

**AFTER:**
![Screenshot 2022-11-30 130612](https://user-images.githubusercontent.com/64202931/204795114-bfb0fee2-bdd7-470c-96d4-8a9a082b6bcc.png)
![Screenshot 2022-11-30 130754](https://user-images.githubusercontent.com/64202931/204795123-646f2300-4bdc-4561-b609-457505f49c6a.png)
![Screenshot 2022-11-30 130802](https://user-images.githubusercontent.com/64202931/204795127-bb552f41-e297-4563-813b-f2df2d36a722.png)
![Screenshot 2022-11-30 130840](https://user-images.githubusercontent.com/64202931/204795129-e44b34a6-cdd5-45d2-b42a-a7d3d4d67364.png)
